### PR TITLE
Remove extra newline on windows

### DIFF
--- a/bmex.py
+++ b/bmex.py
@@ -131,7 +131,7 @@ def _store(start: str, symbols: set, channel: str, path: str, base: str):
                         os.remove(_file)
                     new = False
 
-                with open(_file, "a") as out:
+                with open(_file, "a", newline='\n') as out:
                     write = csv.writer(out)
                     write.writerow(row)
     os.remove(temp)


### PR DESCRIPTION
The generated csv contains an extra line between each entry, at least on windows.  This small changes fixes that.